### PR TITLE
Use publicly accessible submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src/github.com/pivotal-cf-experimental/kafka-example-service-adapter"]
 	path = src/github.com/pivotal-cf-experimental/kafka-example-service-adapter
-	url = git@github.com:pivotal-cf-experimental/kafka-example-service-adapter.git
+	url = https://github.com/pivotal-cf-experimental/kafka-example-service-adapter.git
+	pushurl = git@github.com:pivotal-cf-experimental/kafka-example-service-adapter.git


### PR DESCRIPTION
Move the git@ URL to a pushurl only.

This allows those with push access to push, and those without push
access to fetch.

Without this change, the [official instructions](https://docs.pivotal.io/svc-sdk/odb/0-19/getting-started.html#-step-3:-set-up-the-kafka-example-service-adapter) fail when trying to get the repo.